### PR TITLE
fix: fallback to utf-8 encoding if missing

### DIFF
--- a/lua/ltex-utils/config.lua
+++ b/lua/ltex-utils/config.lua
@@ -73,9 +73,12 @@ function M.setup(opts)
 				dictionary = {
 					path = vim.fn.stdpath("config") .. "/spell/",
 					filename = function(lang)
-						return string.match(lang, "^(%a+)-") .. "." ..
-						vim.api.nvim_buf_get_option(0, "fileencoding") ..
-						".add"
+						local fileencoding = vim.api.nvim_get_option_value(
+							"fileencoding",
+							{ buf = 0 }
+						) or "utf-8"
+
+						return string.match(lang, "^(%a+)-") .. "." .. fileencoding .. ".add"
 					end,
 				}
 			} or {}


### PR DESCRIPTION
When using this plugin together with [clear-action.nvim](https://github.com/luckasRanarison/clear-action.nvim), the file encoding doesn't get set properly when adding a word to Vim's dictionary. I'm guessing that this is because ltex-utils.nvim tries to get the clear-action.nvim's floating code-action window encoding (`nil`), instead of the buffer that ltex-ls is in, causing the error `attempt to concatenate a nil value`.

My fix is to default to `"utf-8"` if the encoding is `nil`.
