### PR TITLE
fix calls to deprecated API

### DIFF
--- a/lua/ltex-utils/diagnostics.lua
+++ b/lua/ltex-utils/diagnostics.lua
@@ -7,7 +7,7 @@ local M = {}
 function M.get_ltex_namespace(bufnr)
 	---@type integer
 	local id
-	for _, client in ipairs(vim.lsp.get_active_clients({ bufnr = bufnr })) do
+	for _, client in ipairs(vim.lsp.get_clients({ bufnr = bufnr })) do
 		if client.name == "ltex" then
 			id = client.id
 			break

--- a/lua/ltex-utils/ltex_lsp.lua
+++ b/lua/ltex-utils/ltex_lsp.lua
@@ -12,12 +12,14 @@ local M = {}
 ---Returns the first active LTeX LSP client attached to a buffer.
 ---NOTE: vim.lsp.buf_get_clients() is deprecated;
 ---use vim.lsp.get_active_clients instead.
+---NOTE: vim.lsp.get_active_clients is deprecated form nvim 0.12;
+---use vim.lsp.get_clients instead.
 ---@param bufnr integer|nil Buffer number; if not provided uses current buffer.
 ---@return table|nil # LTeX LSP client if found, otherwise nil.
 function M.get_ltex(bufnr)
 	bufnr = bufnr or vim.api.nvim_get_current_buf()
 
-	for _, client in ipairs(vim.lsp.get_active_clients({ buffer = bufnr })) do
+	for _, client in ipairs(vim.lsp.get_clients({ bufnr = bufnr })) do
 		if client.name == 'ltex' then
 			return client
 		end


### PR DESCRIPTION
from neovim 0.12 onwards, `vim.lsp.get_active_clients()` is deprecated. This commit replaces the corresponding calls by ones to the updated API.

fixes #16

Caveat: I have not checked the implecations for versions of neovim below 0.12 but this fixes the warnings without breaking functionality for me.