### PR TITLE
fix(init): TelescopePreviewerLoaded allow empty data and buffname

### DIFF
--- a/lua/ltex-utils/init.lua
+++ b/lua/ltex-utils/init.lua
@@ -63,6 +63,9 @@ local function autocmd_ltex()
 		pattern = "TelescopePreviewerLoaded",
 		callback = function(args)
 			---@type string
+      if args.data == nil or args.data.bufname == nil then
+        return
+      end
 			local extension = args.data.bufname:match("%.(%w+)$")
 			if extension == "md" or extension == "tex" then
 				vim.wo.number = Config.rule_ui.previewer_line_number


### PR DESCRIPTION
Fixes #12

[`actions-preview.nvim`](https://github.com/aznhe21/actions-preview.nvim#actions-previewnvim) triggers `TelescopePreviewerLoaded` autocmd, but with a nil `args.data.bufname`. This causes an error when `args.data.bufname` is parsed.

Proposed fix:

```diff
 	vim.api.nvim_create_autocmd("User", {
 		pattern = "TelescopePreviewerLoaded",
 		callback = function(args)
 			---@type string
+			if args.data == nil or args.data.bufname == nil then
+				return
+			end
 			local extension = args.data.bufname:match("%.(%w+)$")
 			if extension == "md" or extension == "tex" then
 				vim.wo.number = Config.rule_ui.previewer_line_number
 				vim.wo.wrap = Config.rule_ui.previewer_wrap
 			end
 		end,
 	})
```

Fixes the error message:

```
Error executing vim.schedule lua callback: ...scope.nvim/lua/telescope/previewers/buffer_previewer.lua:460: User Autocommands for "TelescopePreviewerLoaded": Vim(append):Error executing lua callback: .../share/nvim/lazy/ltex-utils.nvim/lua/ltex-utils/init.lua:66: attempt to index field 'bufname' (a nil value)
stack traceback:
        .../share/nvim/lazy/ltex-utils.nvim/lua/ltex-utils/init.lua:66: in function <.../share/nvim/lazy/ltex-utils.nvim/lua/ltex-utils/init.lua:64>
        [C]: in function 'nvim_exec_autocmds'
        ...scope.nvim/lua/telescope/previewers/buffer_previewer.lua:461: in function <...scope.nvim/lua/telescope/previewers/buffer_previewer.lua:460>
        [C]: in function 'nvim_buf_call'
        ...scope.nvim/lua/telescope/previewers/buffer_previewer.lua:460: in function <...scope.nvim/lua/telescope/previewers/buffer_previewer.lua:454>
```

And a similar message when the `args.data` field is empty.

I recommend adding similar `nil` checks in all functions to avoid errors.