### PR TITLE
fix: save to ~/.local/state/nvim/ltex-utils/file_settings/* instead of $PWD/*_ltex.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Using the mentioned configuration above, activate code actions by pressing `<lea
 Navigate to an LTeX issue within your text (LaTeX, Markdown, etc.), then press `<leader>-ca` and choose a suitable option from the menu to fix the problem.
 
 Upon closing the buffer, LSP server settings (including hidden false positives, disabled rules, used languages, and added dictionary words) are saved to disk.
-Settings are saved in the same folder as your LaTeX/Markdown file under `your_file_ltex.json`.
+Settings are saved in `$XDG_STATE_HOME/nvim/ltex-utils/file_settings/<slugified_filename>` in JSON format.
 Dictionaries are merged with existing (stored) ones and then saved to preserve all words.
 By default, dictionaries are saved in Neovim's cache directory, although this can be customised (see [Installation](#installation)).
 
@@ -174,7 +174,7 @@ Accumulating outdated rules can clutter the `hiddenFalsePositives` list, as LTeX
 
 
 To avoid this, use 'Hide False Positive' sparingly or manually remove obsolete rules through `:LTeXUtils modify_hiddenFalsePositives`.
-Direct modification of `the your_file_ltex.json` settings file is not advised.
+Direct modification of the JSON settings file is not advised.
 Using regular expressions for `hiddenFalsePositives` could help prevent clutter in your hidden false positives list.
 However, bear in mind that hidden false positive rules hide the entire sentence and might not yield the expected behaviour.
 An in-depth explanation is available in the [tutorial](TUTORIAL.md).

--- a/lua/ltex-utils/actions.lua
+++ b/lua/ltex-utils/actions.lua
@@ -6,16 +6,11 @@ local settings_io = require("ltex-utils.settings_io")
 local table_utils = require("ltex-utils.table_utils")
 
 local function ltex_filename(absolutePath)
-    -- Separate path and filename
-    local path, name_with_possible_ext = absolutePath:match("^(.-)([^/]+)$")
+	local rootDir = vim.fn.stdpath("state") .. "/ltex-utils/file_settings/"
+	vim.fn.mkdir(rootDir, "p")
 
-    -- Split filename into name and its optional extension using your pattern
-    local name, ext = name_with_possible_ext:match("^([^%.]*)(%.?.*)$")
-
-    -- Construct the new filename
-    local newName = name .. ext:gsub("%.", "_") .. "_ltex.json"
-
-    return path .. newName
+	local slugPath = absolutePath:gsub("/", "%%"):gsub("\\", "%%"):gsub(":", "%%")
+	return rootDir .. slugPath
 end
 
 ---Generates a code action handler updating LSP server settings with 'cmd_cfg'
@@ -46,8 +41,7 @@ end
 
 ---Writes the current LTeX LSP server settings to a JSON file. It saves the
 ---current dictionaries and their languages, hidden false positives, and
----disabled rules. The settings are written to a JSON file, named
----'current_filename_ltex.json' located in its parent directory.
+---disabled rules.
 function M.write_ltex_to_file(bufnr)
 	---@type integer
 	bufnr = bufnr or vim.api.nvim_get_current_buf()
@@ -105,9 +99,8 @@ end
 
 ---Loads LTeX  LSP settings from JSON file. Updates the active LTeX LSP
 ---server with read settings (hidden false positives, disabled rules, and
----specific language dictionaries). Settings file given by
----'buffer_filename_ltex.json'.  If settings file doesn't exist, an
----notification is printed.
+---specific language dictionaries).
+---If settings file doesn't exist, a notification is printed.
 ---@return boolean # true if successful, false otherwise.
 ---@return string|nil # nil if successful, error message otherwise.
 function M.load_ltex_from_file()


### PR DESCRIPTION
Fixes #5.
Resolves #10.

Places file settings into a centralized directory, just like how `help 'undodir'` places undo files in `~/.local/state/nvim/undo/`.